### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: ci
+permissions:
+  contents: read
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/openkcm/plugin-sdk/security/code-scanning/3](https://github.com/openkcm/plugin-sdk/security/code-scanning/3)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Based on the workflow's steps, it only needs `contents: read` to check out the repository and perform validation and testing. This change ensures that the `GITHUB_TOKEN` has the least privileges necessary, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
