### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -1,7 +1,8 @@
 name: REUSE Compliance Check
 
 on: [push, pull_request]
-
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/openkcm/plugin-sdk/security/code-scanning/2](https://github.com/openkcm/plugin-sdk/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow performs a compliance check, it likely only needs read access to the repository contents. We will add `permissions: contents: read` at the root level of the workflow to apply this restriction to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
