### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   release:
     uses: openkcm/build/.github/workflows/release.lib.yaml@main


### PR DESCRIPTION
Potential fix for [https://github.com/openkcm/plugin-sdk/security/code-scanning/5](https://github.com/openkcm/plugin-sdk/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow. This block will define the minimal permissions required for the workflow to function securely. Based on the context, the workflow likely needs read access to repository contents and possibly write access to pull requests (if it interacts with pull requests). We will set `contents: read` and `pull-requests: write` as a starting point. If additional permissions are required, they can be added later.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
