### PR TITLE
feat: add common keystore plugin errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/go-plugin v1.6.3
 	github.com/zeebo/errs/v2 v2.0.5
 	golang.org/x/sys v0.33.0
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250528174236-200df99c418a
 	google.golang.org/grpc v1.74.2
 	google.golang.org/protobuf v1.36.6
 )
@@ -20,5 +21,4 @@ require (
 	github.com/oklog/run v1.1.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250528174236-200df99c418a // indirect
 )

--- a/pkg/plugin/keystore/errors/errors.go
+++ b/pkg/plugin/keystore/errors/errors.go
@@ -1,0 +1,48 @@
+package errors
+
+import (
+	"fmt"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	StatusProviderAuthenticationError = status.New(
+		codes.InvalidArgument, "failed to authenticate with the keystore provider")
+	StatusKeyNotFound = status.New(
+		codes.NotFound, "key not found in the keystore provider")
+)
+
+// NewGrpcErrorWithReason creates a gRPC error with the given status and reason.
+func NewGrpcErrorWithReason(st *status.Status, reason string) error {
+	errInfo := &errdetails.ErrorInfo{
+		Reason: reason,
+	}
+	st, err := st.WithDetails(errInfo)
+	if err != nil {
+		return fmt.Errorf("failed to add reason to status: %w", err)
+	}
+	return st.Err()
+}
+
+// IsStatus checks if the given error matches the provided gRPC status.
+func IsStatus(err error, st *status.Status) bool {
+	convertedErr := status.Convert(err)
+	return convertedErr.Code() == st.Code() && convertedErr.Message() == st.Message()
+}
+
+// GetReason extracts the reason from the given gRPC error, if available.
+func GetReason(err error) string {
+	st, ok := status.FromError(err)
+	if !ok {
+		return ""
+	}
+	for _, detail := range st.Details() {
+		if errInfo, ok := detail.(*errdetails.ErrorInfo); ok {
+			return errInfo.Reason
+		}
+	}
+	return ""
+}

--- a/pkg/plugin/keystore/errors/errors_test.go
+++ b/pkg/plugin/keystore/errors/errors_test.go
@@ -1,0 +1,24 @@
+package errors_test
+
+import (
+	"testing"
+
+	keystoreErrs "github.com/openkcm/plugin-sdk/pkg/plugin/keystore/errors"
+)
+
+func TestStatusProviderAuthenticationErrorWithDetails(t *testing.T) {
+	err := keystoreErrs.NewGrpcErrorWithReason(
+		keystoreErrs.StatusProviderAuthenticationError,
+		"Invalid credentials",
+	)
+
+	extractedReason := keystoreErrs.GetReason(err)
+	if extractedReason != "Invalid credentials" {
+		t.Errorf("Expected reason 'Invalid credentials', got '%s'", extractedReason)
+	}
+
+	if !keystoreErrs.IsStatus(err, keystoreErrs.StatusProviderAuthenticationError) {
+		t.Errorf("Error does not match StatusProviderAuthenticationError")
+	}
+
+}

--- a/proto/plugin/keystore/operations/v1/operations.proto
+++ b/proto/plugin/keystore/operations/v1/operations.proto
@@ -7,6 +7,10 @@ import "plugin/keystore/common/v1/common.proto";
 // KeystoreInstanceKeyOperation service defines the operations available for key management
 service KeystoreInstanceKeyOperation {
   // GetKey retrieves the details of a key by its ID
+  // * Returns error "code = InvalidArgument desc = failed to authenticate with the keystore provider"
+  // if the provided access data is invalid
+  // * Returns error "code = NotFound desc = key not found in the keystore provider"
+  // if the key does not exist
   rpc GetKey(GetKeyRequest) returns (GetKeyResponse);
 
   // CreateKey generates a new key with the specified algorithm

--- a/proto/plugin/keystore/operations/v1/operations_grpc.pb.go
+++ b/proto/plugin/keystore/operations/v1/operations_grpc.pb.go
@@ -37,6 +37,10 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type KeystoreInstanceKeyOperationClient interface {
 	// GetKey retrieves the details of a key by its ID
+	// * Returns error "code = InvalidArgument desc = failed to authenticate with the keystore provider"
+	// if the provided access data is invalid
+	// * Returns error "code = NotFound desc = key not found in the keystore provider"
+	// if the key does not exist
 	GetKey(ctx context.Context, in *GetKeyRequest, opts ...grpc.CallOption) (*GetKeyResponse, error)
 	// CreateKey generates a new key with the specified algorithm
 	CreateKey(ctx context.Context, in *CreateKeyRequest, opts ...grpc.CallOption) (*CreateKeyResponse, error)
@@ -172,6 +176,10 @@ func (c *keystoreInstanceKeyOperationClient) ExtractKeyRegion(ctx context.Contex
 // for forward compatibility
 type KeystoreInstanceKeyOperationServer interface {
 	// GetKey retrieves the details of a key by its ID
+	// * Returns error "code = InvalidArgument desc = failed to authenticate with the keystore provider"
+	// if the provided access data is invalid
+	// * Returns error "code = NotFound desc = key not found in the keystore provider"
+	// if the key does not exist
 	GetKey(context.Context, *GetKeyRequest) (*GetKeyResponse, error)
 	// CreateKey generates a new key with the specified algorithm
 	CreateKey(context.Context, *CreateKeyRequest) (*CreateKeyResponse, error)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add gRPC error definitions with detailed reason that can be used by both keystore plugins and CMK

**Release note**:
NONE
